### PR TITLE
Fix: gate Slimproto registration on renderer availability + watchdog for hard shutdown detection

### DIFF
--- a/src/UPnPController.cpp
+++ b/src/UPnPController.cpp
@@ -57,6 +57,7 @@ bool UPnPController::init(const std::string& networkInterface) {
 void UPnPController::shutdown() {
     if (!m_initialized) return;
 
+    stopWatchdog();
     m_ready.store(false);
 
     if (m_clientHandle >= 0) {
@@ -72,6 +73,61 @@ void UPnPController::shutdown() {
 std::string UPnPController::getServerIP() const {
     char* ip = UpnpGetServerIpAddress();
     return ip ? std::string(ip) : "";
+}
+
+// ============================================================================
+// Watchdog
+// ============================================================================
+
+void UPnPController::startWatchdog(int probeIntervalSec) {
+    if (m_watchdogRunning.load()) return;  // Already running
+
+    m_watchdogRunning.store(true);
+    m_watchdogThread = std::thread([this, probeIntervalSec]() {
+        LOG_DEBUG("[UPnP] Watchdog started (interval=" << probeIntervalSec << "s)");
+
+        while (m_watchdogRunning.load()) {
+            // Interruptible sleep: wakes immediately on stopWatchdog()
+            {
+                std::unique_lock<std::mutex> lock(m_watchdogMutex);
+                m_watchdogCv.wait_for(lock,
+                    std::chrono::seconds(probeIntervalSec),
+                    [this] { return !m_watchdogRunning.load(); });
+            }
+            if (!m_watchdogRunning.load()) break;
+
+            // Only probe when we believe the renderer is ready.
+            // If it's already marked not-ready (BYEBYE or previous probe failure),
+            // skip — the connection loop is already waiting for ALIVE.
+            if (!m_ready.load()) continue;
+
+            // Lightweight probe: GetTransportInfo via SOAP.
+            // sendAction() already sets m_ready=false on socket errors,
+            // which is exactly what we need for hard-shutdown detection.
+            LOG_DEBUG("[UPnP] Watchdog probing renderer...");
+            std::string state = getTransportState();
+            if (state == "UNKNOWN") {
+                // sendAction() will have already set m_ready=false if it was
+                // a socket-level failure. Log here for visibility.
+                LOG_WARN("[UPnP] Watchdog: probe failed — renderer unreachable");
+            } else {
+                LOG_DEBUG("[UPnP] Watchdog: renderer alive, state=" << state);
+            }
+        }
+
+        LOG_DEBUG("[UPnP] Watchdog stopped");
+    });
+}
+
+void UPnPController::stopWatchdog() {
+    if (!m_watchdogRunning.load()) return;
+
+    m_watchdogRunning.store(false);
+    m_watchdogCv.notify_all();  // Wake sleeping watchdog immediately
+
+    if (m_watchdogThread.joinable()) {
+        m_watchdogThread.join();
+    }
 }
 
 // ============================================================================

--- a/src/UPnPController.h
+++ b/src/UPnPController.h
@@ -21,6 +21,7 @@
 #include <mutex>
 #include <condition_variable>
 #include <atomic>
+#include <thread>
 #include <cstdint>
 
 class UPnPController {
@@ -104,6 +105,15 @@ public:
     const RendererInfo& getRenderer() const { return m_renderer; }
     bool isReady() const { return m_ready.load(); }
 
+    /// Start background watchdog thread that actively probes the renderer
+    /// every probIntervalSec seconds via GetTransportInfo. If the probe fails
+    /// (host gone, network loss), m_ready is set false so the Slimproto
+    /// connection loop can react. Call after successful discovery.
+    void startWatchdog(int probeIntervalSec = 10);
+
+    /// Stop the watchdog thread. Called automatically by shutdown().
+    void stopWatchdog();
+
     /// Server IP as seen by libupnp (useful for AudioHttpServer).
     std::string getServerIP() const;
 
@@ -150,6 +160,12 @@ private:
     std::atomic<bool> m_ready{false};
     bool m_initialized = false;
     mutable std::mutex m_mutex;
+
+    // --- Watchdog ---
+    std::thread m_watchdogThread;
+    std::atomic<bool> m_watchdogRunning{false};
+    std::condition_variable m_watchdogCv;
+    std::mutex m_watchdogMutex;
 
     // --- Discovery synchronization ---
     std::mutex m_discoveryMutex;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -391,6 +391,13 @@ int main(int argc, char* argv[]) {
 
     UPnPController* upnpPtr = upnp.get();
 
+    // Start watchdog: actively probes the renderer every 10 seconds.
+    // Detects hard shutdowns (power loss, network drop, Pi reboot) where
+    // no BYEBYE announcement is sent. On probe failure, sendAction() sets
+    // m_ready=false, which causes the connection loop to drop Slimproto
+    // and show the player as offline in Roon.
+    upnp->startWatchdog(5);
+
     // ============================================
     // Start Audio HTTP Server
     // ============================================

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1135,6 +1135,18 @@ int main(int argc, char* argv[]) {
     // ============================================
     // Connection loop with exponential backoff
     // ============================================
+    //
+    // slim2UPnP only registers with LMS/Roon when the UPnP renderer is ready.
+    // If the renderer disappears (BYEBYE, SOAP error), Slimproto is disconnected
+    // so Roon sees the player go offline. When the renderer comes back (ALIVE),
+    // the player reconnects and becomes visible in Roon again.
+    //
+    // UPnPController already manages isReady() via:
+    //  - UPNP_DISCOVERY_ADVERTISEMENT_BYEBYE → m_ready = false
+    //  - UPNP_DISCOVERY_ADVERTISEMENT_ALIVE  → re-parse description, m_ready = true
+    //  - sendAction() SOCKET_CONNECT/SOCKET_ERROR → m_ready = false
+    //
+    // This loop adds the Slimproto connect/disconnect side of that contract.
 
     constexpr int INITIAL_BACKOFF_S = 2;
     constexpr int MAX_BACKOFF_S = 30;
@@ -1142,6 +1154,25 @@ int main(int argc, char* argv[]) {
     int connectionCount = 0;
 
     while (g_running.load(std::memory_order_acquire)) {
+
+        // --- Gate: wait for renderer to be ready before registering with LMS ---
+        if (!upnpPtr->isReady()) {
+            if (connectionCount == 0) {
+                // First startup: renderer not yet ready (should not happen — discoverRenderer
+                // already waits, but guard against a race on connectDirect path)
+                LOG_WARN("Renderer not ready at startup — waiting...");
+            } else {
+                // Renderer was lost: log once then poll silently
+                LOG_WARN("Renderer unavailable — waiting before reconnecting to LMS...");
+            }
+            while (g_running.load(std::memory_order_acquire) && !upnpPtr->isReady()) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(500));
+            }
+            if (!g_running.load(std::memory_order_acquire)) break;
+            LOG_INFO("Renderer ready — connecting to LMS");
+        }
+
+        // --- Reconnect backoff (skip on very first connection) ---
         if (connectionCount > 0) {
             LOG_WARN("Reconnecting to LMS in " << backoffS << "s...");
             if (!interruptibleSleep(backoffS)) break;
@@ -1171,7 +1202,14 @@ int main(int argc, char* argv[]) {
         }
         std::cout << std::endl;
 
+        // Monitor: stay connected while both LMS and renderer are up.
+        // When the renderer goes away (isReady() → false), drop the Slimproto
+        // connection so Roon sees the player go offline immediately.
         while (g_running.load(std::memory_order_acquire) && slimproto->isConnected()) {
+            if (!upnpPtr->isReady()) {
+                LOG_WARN("Renderer lost — disconnecting from LMS (player offline in Roon)");
+                break;  // Fall through to stopAudioThread + disconnect below
+            }
             std::this_thread::sleep_for(std::chrono::seconds(1));
         }
 
@@ -1182,7 +1220,16 @@ int main(int argc, char* argv[]) {
         }
 
         if (!g_running.load(std::memory_order_acquire)) break;
-        LOG_WARN("Lost connection to LMS");
+
+        if (!upnpPtr->isReady()) {
+            // Renderer-triggered disconnect: loop back to the renderer gate above.
+            // Do NOT print "Lost connection to LMS" — it was an intentional drop.
+            LOG_INFO("Waiting for renderer to come back...");
+            // Reset backoff — this is a renderer issue, not an LMS issue
+            backoffS = INITIAL_BACKOFF_S;
+        } else {
+            LOG_WARN("Lost connection to LMS");
+        }
     }
 
     // ============================================


### PR DESCRIPTION
Problem
slim2UPnP registered with LMS/Roon immediately at startup, regardless of whether the UPnP renderer (e.g. DirettaRendererUPnP) was running. This caused two issues:

Startup: Roon showed the player as available and attempted to stream to it even when the renderer was not running yet.
Hard shutdown: When the Raspberry Pi hosting the renderer lost power, rebooted, or dropped off the network, Roon kept showing the player as available. Because no UPnP BYEBYE announcement is sent in a hard shutdown, the existing BYEBYE handler could not detect this situation.

Root cause
The Slimproto HELO registration and UPnP renderer discovery were two independent steps with no gate between them. Additionally, the BYEBYE-based detection only works for graceful shutdowns — a hard power loss or network drop produces silence, not an announcement.
Fix
1 — Renderer availability gate (main.cpp)
The Slimproto connection loop now waits for UPnPController::isReady() before sending HELO to LMS. If the renderer goes away while the player is registered, the Slimproto connection is dropped immediately, causing Roon to show the player as offline. When the renderer comes back, the player reconnects automatically.
UPnPController already managed m_ready correctly via:

UPNP_DISCOVERY_ADVERTISEMENT_BYEBYE → m_ready = false
UPNP_DISCOVERY_ADVERTISEMENT_ALIVE → re-parse description, m_ready = true
sendAction() socket errors → m_ready = false

No changes were needed in UPnPController for this part.
2 — Active watchdog for hard shutdown detection (UPnPController.h, UPnPController.cpp, main.cpp)
A background watchdog thread is started after successful renderer discovery. It probes the renderer every 10 seconds via a lightweight GetTransportInfo SOAP call. If the Pi is gone, the resulting socket error in sendAction() sets m_ready = false, which triggers the connection loop to drop the Slimproto connection and show the player as offline in Roon — typically within 10 seconds of the Pi disappearing.
The probe interval can be tuned via the startWatchdog() parameter in main.cpp.
Files changed

src/main.cpp — renderer gate in connection loop + watchdog start
src/UPnPController.h — startWatchdog() / stopWatchdog() declarations + thread members
src/UPnPController.cpp — watchdog implementation + stopWatchdog() call in shutdown()

Audio quality
No impact. Both fixes operate exclusively in the control plane (Slimproto TCP, UPnP SOAP). The audio data path, ring buffer, and Diretta protocol are not touched in any way.