### PR TITLE
fix: stop forcing renderer volume to 100% by default (issue #6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.1.25-beta] - 2026-06-14
+
+### Changed
+- **Volume is no longer forced to 100% by default** (Reported by smoothquark, issue #6): slim2UPnP previously called `SetVolume(100)` on every renderer connect, which was intended for bit-perfect renderers that ignore volume (DirettaRendererUPnP). On a real amplifier/preamp such as the Lyngdorf TDAI-3400 this drove the output to full scale on startup — potentially dangerous. The renderer's volume is now left untouched by default. Forcing 100% is available as an opt-in via the new `--set-volume-100` flag (config `SET_VOLUME_100="yes"`, also exposed in the webUI), to be used **only** with renderers that ignore volume.
+
+### Added
+- `--set-volume-100` CLI flag / `SET_VOLUME_100` config var / webUI toggle to force the renderer volume to 100% on connect (off by default).
+
 ## [0.1.24-beta] - 2026-05-11
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,7 @@ Key messages: HELO (registration), STAT (status), strm (stream control), audg (v
 
 ### Implemented UPnP services
 - **AVTransport**: SetAVTransportURI, SetNextAVTransportURI, Play, Stop, Pause, GetPositionInfo, GetTransportInfo
-- **RenderingControl**: SetVolume (force 100%), GetVolume
+- **RenderingControl**: SetVolume (opt-in force 100% via `--set-volume-100`), GetVolume
 - **ConnectionManager**: GetProtocolInfo (check supported formats)
 
 ### Discovery
@@ -192,7 +192,7 @@ Unlike slim2diretta (which depends on the proprietary Diretta SDK), slim2UPnP ha
 
 ## Important Notes
 
-- Volume forced to 100% for bit-perfect playback
+- Volume is left untouched by default (bit-perfect at the renderer's current level). `--set-volume-100` opt-in forces 100% on connect — only for renderers that ignore volume (DirettaRendererUPnP); unsafe on a real amp/preamp (e.g. Lyngdorf)
 - No automated tests — manual testing with LMS + UPnP renderer + DAC
 - Primary target: Linux (cross-platform as stretch goal)
 - Version is tracked in `src/main.cpp` (`SLIM2UPNP_VERSION`) and `CMakeLists.txt`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-project(slim2upnp VERSION 0.1.24)
+project(slim2upnp VERSION 0.1.25)
 
 set(CMAKE_CXX_STANDARD 17)
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Audio:
   --max-rate <hz>          Max sample rate (default: 1536000)
   --no-dsd                 Disable DSD support
   --no-play-calibration    Disable renderer PLAYING-state elapsed calibration
+  --set-volume-100         Force renderer volume to 100% on connect
+                           (bit-perfect renderers only — see note below)
 
 Logging:
   -v, --verbose            Debug output
@@ -98,6 +100,17 @@ Other:
   -V, --version            Show version
   -h, --help               Show help
 ```
+
+### Volume handling
+
+By default, slim2UPnP **does not touch the renderer's volume** — playback is
+bit-perfect at whatever level the renderer is already set to.
+
+`--set-volume-100` forces the renderer volume to 100% on connect. Use it **only**
+with bit-perfect renderers that ignore volume (e.g. DirettaRendererUPnP).
+
+> ⚠️ Do **not** enable `--set-volume-100` when the renderer is a real amplifier
+> or preamp (e.g. Lyngdorf): it would drive the output to full scale.
 
 ## Building
 

--- a/dist/slim2upnp.default
+++ b/dist/slim2upnp.default
@@ -43,6 +43,13 @@ PLAYER_NAME=""
 # Set to "yes" to disable DSD and force PCM output
 NO_DSD=""
 
+# Set to "yes" to force the renderer volume to 100% on connect.
+# Only for bit-perfect renderers that ignore volume (e.g. DirettaRendererUPnP).
+# WARNING: do NOT enable this with a real amplifier/preamp (e.g. Lyngdorf) —
+# it would set the output to full scale. Leave empty to keep the renderer's
+# own volume untouched.
+SET_VOLUME_100=""
+
 # ── Network Options ───────────────────────────────────────────────────────
 # Force a specific network interface (e.g., eth0, enp3s0)
 INTERFACE=""

--- a/dist/start-slim2upnp.sh
+++ b/dist/start-slim2upnp.sh
@@ -21,6 +21,7 @@ fi
 [ -n "$LMS_SERVER" ]   && ARGS+=(-s "$LMS_SERVER")
 [ -n "$PLAYER_NAME" ]  && ARGS+=(-n "$PLAYER_NAME")
 [ "$NO_DSD" = "yes" ]  && ARGS+=(--no-dsd)
+[ "$SET_VOLUME_100" = "yes" ] && ARGS+=(--set-volume-100)
 [ -n "$INTERFACE" ]    && ARGS+=(--interface "$INTERFACE")
 [ -n "$HTTP_PORT" ]    && ARGS+=(--http-port "$HTTP_PORT")
 [ "$VERBOSE" = "yes" ] && ARGS+=(-v)

--- a/install.sh
+++ b/install.sh
@@ -442,12 +442,14 @@ install_systemd() {
         # Save user values from existing config
         local saved_renderer="" saved_renderer_url="" saved_lms="" saved_player=""
         local saved_no_dsd="" saved_interface="" saved_http_port="" saved_verbose=""
+        local saved_set_volume_100=""
         . /etc/default/slim2upnp 2>/dev/null || true
         saved_renderer="$RENDERER"
         saved_renderer_url="$RENDERER_URL"
         saved_lms="$LMS_SERVER"
         saved_player="$PLAYER_NAME"
         saved_no_dsd="$NO_DSD"
+        saved_set_volume_100="$SET_VOLUME_100"
         saved_interface="$INTERFACE"
         saved_http_port="$HTTP_PORT"
         saved_verbose="$VERBOSE"
@@ -461,6 +463,7 @@ install_systemd() {
         [ -n "$saved_lms" ] && sed -i "s|^LMS_SERVER=.*|LMS_SERVER=\"$saved_lms\"|" /etc/default/slim2upnp
         [ -n "$saved_player" ] && sed -i "s|^PLAYER_NAME=.*|PLAYER_NAME=\"$saved_player\"|" /etc/default/slim2upnp
         [ -n "$saved_no_dsd" ] && sed -i "s|^NO_DSD=.*|NO_DSD=\"$saved_no_dsd\"|" /etc/default/slim2upnp
+        [ -n "$saved_set_volume_100" ] && sed -i "s|^SET_VOLUME_100=.*|SET_VOLUME_100=\"$saved_set_volume_100\"|" /etc/default/slim2upnp
         [ -n "$saved_interface" ] && sed -i "s|^INTERFACE=.*|INTERFACE=\"$saved_interface\"|" /etc/default/slim2upnp
         [ -n "$saved_http_port" ] && sed -i "s|^HTTP_PORT=.*|HTTP_PORT=\"$saved_http_port\"|" /etc/default/slim2upnp
         [ -n "$saved_verbose" ] && sed -i "s|^VERBOSE=.*|VERBOSE=\"$saved_verbose\"|" /etc/default/slim2upnp
@@ -511,12 +514,14 @@ install_openrc() {
     if [ -f /etc/conf.d/slim2upnp ]; then
         local saved_renderer="" saved_renderer_url="" saved_lms="" saved_player=""
         local saved_no_dsd="" saved_interface="" saved_http_port="" saved_verbose=""
+        local saved_set_volume_100=""
         . /etc/conf.d/slim2upnp 2>/dev/null || true
         saved_renderer="$RENDERER"
         saved_renderer_url="$RENDERER_URL"
         saved_lms="$LMS_SERVER"
         saved_player="$PLAYER_NAME"
         saved_no_dsd="$NO_DSD"
+        saved_set_volume_100="$SET_VOLUME_100"
         saved_interface="$INTERFACE"
         saved_http_port="$HTTP_PORT"
         saved_verbose="$VERBOSE"
@@ -528,6 +533,7 @@ install_openrc() {
         [ -n "$saved_lms" ] && sed -i "s|^LMS_SERVER=.*|LMS_SERVER=\"$saved_lms\"|" /etc/conf.d/slim2upnp
         [ -n "$saved_player" ] && sed -i "s|^PLAYER_NAME=.*|PLAYER_NAME=\"$saved_player\"|" /etc/conf.d/slim2upnp
         [ -n "$saved_no_dsd" ] && sed -i "s|^NO_DSD=.*|NO_DSD=\"$saved_no_dsd\"|" /etc/conf.d/slim2upnp
+        [ -n "$saved_set_volume_100" ] && sed -i "s|^SET_VOLUME_100=.*|SET_VOLUME_100=\"$saved_set_volume_100\"|" /etc/conf.d/slim2upnp
         [ -n "$saved_interface" ] && sed -i "s|^INTERFACE=.*|INTERFACE=\"$saved_interface\"|" /etc/conf.d/slim2upnp
         [ -n "$saved_http_port" ] && sed -i "s|^HTTP_PORT=.*|HTTP_PORT=\"$saved_http_port\"|" /etc/conf.d/slim2upnp
         [ -n "$saved_verbose" ] && sed -i "s|^VERBOSE=.*|VERBOSE=\"$saved_verbose\"|" /etc/conf.d/slim2upnp

--- a/src/Config.h
+++ b/src/Config.h
@@ -31,6 +31,8 @@ struct Config {
     int maxSampleRate = 1536000;
     bool dsdEnabled = true;
     bool calibrateElapsed = true;       // poll GetTransportInfo at start to align elapsed clock with renderer PLAYING state
+    bool forceVolume100 = false;        // force renderer volume to 100% on connect (bit-perfect renderers like DirettaRendererUPnP).
+                                        // OFF by default — forcing 100% on a real amp/preamp (e.g. Lyngdorf) is dangerous.
 
     // Logging
     bool verbose = false;

--- a/src/UPnPController.cpp
+++ b/src/UPnPController.cpp
@@ -192,8 +192,12 @@ bool UPnPController::discoverRenderer(const std::string& rendererMatch,
     // Query protocol info after discovery
     queryProtocolInfo();
 
-    // Force volume to 100% for bit-perfect playback
-    setVolume(100);
+    // Force volume to 100% only when explicitly requested (bit-perfect
+    // renderers like DirettaRendererUPnP). Off by default — forcing 100%
+    // on a real amp/preamp is dangerous.
+    if (m_forceVolume100) {
+        setVolume(100);
+    }
 
     LOG_INFO("[UPnP] Renderer found: " << m_renderer.friendlyName
              << " (" << m_renderer.uuid << ")");
@@ -250,7 +254,9 @@ bool UPnPController::connectDirect(const std::string& descriptionURL) {
     }
 
     queryProtocolInfo();
-    setVolume(100);
+    if (m_forceVolume100) {
+        setVolume(100);
+    }
 
     LOG_INFO("[UPnP] Connected to: " << m_renderer.friendlyName
              << " (" << m_renderer.uuid << ")");

--- a/src/UPnPController.h
+++ b/src/UPnPController.h
@@ -78,6 +78,12 @@ public:
 
     // --- RenderingControl ---
 
+    /// If enabled, the renderer volume is forced to 100% on connect (for
+    /// bit-perfect renderers that ignore volume, e.g. DirettaRendererUPnP).
+    /// Disabled by default: forcing 100% on a real amp/preamp is dangerous.
+    /// Call before discoverRenderer()/connectDirect().
+    void setForceVolume100(bool enable) { m_forceVolume100 = enable; }
+
     bool setVolume(int volume);
     int getVolume();
 
@@ -159,6 +165,7 @@ private:
     RendererInfo m_renderer;
     std::atomic<bool> m_ready{false};
     bool m_initialized = false;
+    bool m_forceVolume100 = false;      // see setForceVolume100()
     mutable std::mutex m_mutex;
 
     // --- Watchdog ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,7 +35,7 @@
 #include <unistd.h>
 #include <poll.h>
 
-#define SLIM2UPNP_VERSION "0.1.24-beta"
+#define SLIM2UPNP_VERSION "0.1.25-beta"
 
 // ============================================
 // Globals
@@ -184,6 +184,9 @@ Config parseArguments(int argc, char* argv[]) {
         else if (arg == "--no-play-calibration") {
             config.calibrateElapsed = false;
         }
+        else if (arg == "--set-volume-100") {
+            config.forceVolume100 = true;
+        }
         else if (arg == "--list-renderers" || arg == "-l") {
             config.listRenderers = true;
         }
@@ -218,6 +221,9 @@ Config parseArguments(int argc, char* argv[]) {
                       << "  --max-rate <hz>        Max sample rate (default: 1536000)\n"
                       << "  --no-dsd               Disable DSD support\n"
                       << "  --no-play-calibration  Disable renderer PLAYING-state elapsed calibration\n"
+                      << "  --set-volume-100       Force renderer volume to 100% on connect\n"
+                      << "                         (for bit-perfect renderers like DirettaRendererUPnP;\n"
+                      << "                          OFF by default — unsafe on a real amp/preamp)\n"
                       << "\n"
                       << "Logging:\n"
                       << "  -v, --verbose          Debug output (log level: DEBUG)\n"
@@ -369,6 +375,7 @@ int main(int argc, char* argv[]) {
         std::cerr << "Failed to initialize UPnP" << std::endl;
         return 1;
     }
+    upnp->setForceVolume100(config.forceVolume100);
 
     // Connect to renderer: direct URL or SSDP discovery
     if (!config.rendererURL.empty()) {
@@ -472,6 +479,7 @@ int main(int argc, char* argv[]) {
     std::cout << "  HTTP B:     " << audioServerB->getStreamURL() << std::endl;
     std::cout << "  Max Rate:   " << config.maxSampleRate << " Hz" << std::endl;
     std::cout << "  DSD:        " << (config.dsdEnabled ? "enabled" : "disabled") << std::endl;
+    std::cout << "  Volume:     " << (config.forceVolume100 ? "forced to 100%" : "untouched") << std::endl;
     if (!config.macAddress.empty()) {
         std::cout << "  MAC:        " << config.macAddress << std::endl;
     }

--- a/webui/profiles/slim2upnp.json
+++ b/webui/profiles/slim2upnp.json
@@ -61,6 +61,17 @@
                         {"value": "", "label": "No (DSD enabled)"},
                         {"value": "yes", "label": "Yes (force PCM only)"}
                     ]
+                },
+                {
+                    "key": "SET_VOLUME_100",
+                    "type": "select",
+                    "label": "Force volume to 100%",
+                    "description": "Force the renderer volume to 100% on connect. ONLY for bit-perfect renderers that ignore volume (e.g. DirettaRendererUPnP). WARNING: do NOT enable with a real amplifier/preamp (e.g. Lyngdorf) — it sets the output to full scale.",
+                    "default": "",
+                    "options": [
+                        {"value": "", "label": "No (leave volume untouched)"},
+                        {"value": "yes", "label": "Yes (force 100% — bit-perfect renderers only)"}
+                    ]
                 }
             ]
         },


### PR DESCRIPTION
## Problem

slim2UPnP called `SetVolume(100)` on every renderer connect (`UPnPController::discoverRenderer` and `connectDirect`). This was meant for bit-perfect renderers that ignore volume (DirettaRendererUPnP).

On a **real amplifier/preamp such as the Lyngdorf TDAI-3400** this drove the output to full scale on startup — potentially dangerous. Reported by @smoothquark in #6 (point 3).

## Change

- Renderer volume is now **left untouched by default**.
- Forcing 100% is available as an **opt-in**:
  - CLI: `--set-volume-100`
  - service config: `SET_VOLUME_100="yes"`
  - webUI: "Force volume to 100%" toggle (Audio group, with warning)
- To be used **only** with renderers that ignore volume (DirettaRendererUPnP).

Existing DirettaRendererUPnP users are unaffected in practice — that renderer ignores volume, so leaving it untouched changes nothing audible for them.

Version bumped to **0.1.25-beta**. Docs (README/CLAUDE/CHANGELOG), wrapper script, default config and `install.sh` upgrade-preservation updated accordingly.

Addresses point 3 of #6. The remaining playback issues in #4/#5/#6 (DLNA metadata / GStreamer compatibility) are tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)