### PR TITLE
DLNA compatibility: DIDL-Lite metadata + DLNA HTTP headers + volume safety (#4 #5 #6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.1.25-beta] - 2026-06-14
+
+### Changed
+- **Volume is no longer forced to 100% by default** (Reported by smoothquark, issue #6): slim2UPnP previously called `SetVolume(100)` on every renderer connect, which was intended for bit-perfect renderers that ignore volume (DirettaRendererUPnP). On a real amplifier/preamp such as the Lyngdorf TDAI-3400 this drove the output to full scale on startup — potentially dangerous. The renderer's volume is now left untouched by default. Forcing 100% is available as an opt-in via the new `--set-volume-100` flag (config `SET_VOLUME_100="yes"`, also exposed in the webUI), to be used **only** with renderers that ignore volume.
+
+### Added
+- `--set-volume-100` CLI flag / `SET_VOLUME_100` config var / webUI toggle to force the renderer volume to 100% on connect (off by default).
+
 ## [0.1.24-beta] - 2026-05-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.1.26-beta] - 2026-06-14
+
+### Added
+- **DIDL-Lite metadata in `SetAVTransportURI`/`SetNextAVTransportURI`** (Reported by smoothquark, issues #4 #5 #6): slim2UPnP previously set the transport URI with empty metadata. Strict DLNA renderers — GStreamer-based ones (e.g. Lyngdorf TDAI-3400) and DSD-capable ones (e.g. Zidoo Z3000 Pro) — need a `<res protocolInfo="http-get:*:MIME:DLNA.ORG_*">` descriptor to accept the URI. Without it the Lyngdorf never started playback and the Zidoo silently refused DSF streams (it never even connected to fetch the audio). A minimal DIDL-Lite item (with `protocolInfo` describing a non-seekable HTTP audio stream, `DLNA.ORG_OP=00`) is now generated and sent. Can be disabled for A/B testing with `--no-didl-metadata`.
+- **`contentFeatures.dlna.org` HTTP response header + HEAD support** in the audio server: GStreamer-based renderers send a `getContentFeatures.dlna.org` probe and a `HEAD`/probe request before streaming, and reject the stream if the server doesn't advertise DLNA content features. The server now returns `contentFeatures.dlna.org` (matching the DIDL `protocolInfo`) and answers `HEAD` requests with headers only.
+
+### Fixed
+- **Misleading `Format:` log line for DSD passthrough**: DSD streams were logged as `44100 Hz, 24-bit` (placeholder values used only to size the ring buffer) with no DSD marker. The format is now flagged as DSD from the content type, so the log shows `(DSD)` and the ring buffer uses the DSD size multiplier.
+
+### Changed
+- Version updated to 0.1.26-beta
+
+> **Note:** the DIDL-Lite / DLNA-header changes target renderers the maintainer does not own (Lyngdorf, Zidoo). They are standards-based and verified for well-formedness, but field-testing on those devices (via smoothquark) is pending. `--no-didl-metadata` is provided as a fallback.
+
 ## [0.1.25-beta] - 2026-06-14
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.1.27-beta] - 2026-06-14
+
+### Fixed
+- **No sound on DSD (regression in 0.1.26-beta)**: the 0.1.26 "flag DSD in passthrough format" change set `isDSD=true` on the placeholder format. `AudioFormat::bytesPerSecond()` computes DSD throughput as `(dsdRate/8)*channels`, but `dsdRate` is 0 in passthrough (never parsed), so it returned 0 → the ring buffer collapsed to `MIN_BUFFER_SIZE` (64 KB), below the 256 KB prebuffer target → `writeAudio()` deadlocked before `SetAVTransportURI`/`Play` were ever sent (renderer stuck, no audio). Reverted: passthrough no longer flags DSD on the placeholder format (it is only used to size the ring buffer with PCM math, ~1 MB). The cosmetic "(DSD)" log marker is dropped again — correctness over cosmetics. (Found by regression-testing DSF on DirettaRendererUPnP)
+- **Hardened against the same class of deadlock**: `MIN_BUFFER_SIZE` raised from 64 KB to 512 KB so the ring buffer can never be smaller than the 256 KB prebuffer target, regardless of the (placeholder) format.
+
+### Changed
+- Version updated to 0.1.27-beta
+
 ## [0.1.26-beta] - 2026-06-14
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,7 @@ Key messages: HELO (registration), STAT (status), strm (stream control), audg (v
 
 ### Implemented UPnP services
 - **AVTransport**: SetAVTransportURI, SetNextAVTransportURI, Play, Stop, Pause, GetPositionInfo, GetTransportInfo
-- **RenderingControl**: SetVolume (force 100%), GetVolume
+- **RenderingControl**: SetVolume (opt-in force 100% via `--set-volume-100`), GetVolume
 - **ConnectionManager**: GetProtocolInfo (check supported formats)
 
 ### Discovery
@@ -192,7 +192,7 @@ Unlike slim2diretta (which depends on the proprietary Diretta SDK), slim2UPnP ha
 
 ## Important Notes
 
-- Volume forced to 100% for bit-perfect playback
+- Volume is left untouched by default (bit-perfect at the renderer's current level). `--set-volume-100` opt-in forces 100% on connect — only for renderers that ignore volume (DirettaRendererUPnP); unsafe on a real amp/preamp (e.g. Lyngdorf)
 - No automated tests — manual testing with LMS + UPnP renderer + DAC
 - Primary target: Linux (cross-platform as stretch goal)
 - Version is tracked in `src/main.cpp` (`SLIM2UPNP_VERSION`) and `CMakeLists.txt`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-project(slim2upnp VERSION 0.1.24)
+project(slim2upnp VERSION 0.1.25)
 
 set(CMAKE_CXX_STANDARD 17)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-project(slim2upnp VERSION 0.1.25)
+project(slim2upnp VERSION 0.1.26)
 
 set(CMAKE_CXX_STANDARD 17)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-project(slim2upnp VERSION 0.1.26)
+project(slim2upnp VERSION 0.1.27)
 
 set(CMAKE_CXX_STANDARD 17)
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Audio:
   --no-play-calibration    Disable renderer PLAYING-state elapsed calibration
   --set-volume-100         Force renderer volume to 100% on connect
                            (bit-perfect renderers only — see note below)
+  --no-didl-metadata       Don't send DIDL-Lite metadata in SetAVTransportURI
+                           (metadata is sent by default; needed by strict DLNA renderers)
 
 Logging:
   -v, --verbose            Debug output

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Audio:
   --max-rate <hz>          Max sample rate (default: 1536000)
   --no-dsd                 Disable DSD support
   --no-play-calibration    Disable renderer PLAYING-state elapsed calibration
+  --set-volume-100         Force renderer volume to 100% on connect
+                           (bit-perfect renderers only — see note below)
 
 Logging:
   -v, --verbose            Debug output
@@ -98,6 +100,17 @@ Other:
   -V, --version            Show version
   -h, --help               Show help
 ```
+
+### Volume handling
+
+By default, slim2UPnP **does not touch the renderer's volume** — playback is
+bit-perfect at whatever level the renderer is already set to.
+
+`--set-volume-100` forces the renderer volume to 100% on connect. Use it **only**
+with bit-perfect renderers that ignore volume (e.g. DirettaRendererUPnP).
+
+> ⚠️ Do **not** enable `--set-volume-100` when the renderer is a real amplifier
+> or preamp (e.g. Lyngdorf): it would drive the output to full scale.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -203,8 +203,12 @@ cmake -B build -DTARGET_MARCH=v4       # AVX-512
 ```bash
 git clone https://github.com/cometdom/slim2UPnP.git
 cd slim2UPnP
-sudo ./install.sh
+sudo ./install.sh           # downloads the latest released binary
+# or
+sudo ./install.sh --build   # compiles the current checkout instead
 ```
+
+> **Note:** plain `sudo ./install.sh` always installs the **latest published release**, regardless of which branch/commit you have checked out. To install the code you currently have (e.g. a feature/beta branch or local changes), use `sudo ./install.sh --build`, which compiles from source.
 
 ### Update to latest version
 

--- a/dist/slim2upnp.default
+++ b/dist/slim2upnp.default
@@ -43,6 +43,13 @@ PLAYER_NAME=""
 # Set to "yes" to disable DSD and force PCM output
 NO_DSD=""
 
+# Set to "yes" to force the renderer volume to 100% on connect.
+# Only for bit-perfect renderers that ignore volume (e.g. DirettaRendererUPnP).
+# WARNING: do NOT enable this with a real amplifier/preamp (e.g. Lyngdorf) —
+# it would set the output to full scale. Leave empty to keep the renderer's
+# own volume untouched.
+SET_VOLUME_100=""
+
 # ── Network Options ───────────────────────────────────────────────────────
 # Force a specific network interface (e.g., eth0, enp3s0)
 INTERFACE=""

--- a/dist/start-slim2upnp.sh
+++ b/dist/start-slim2upnp.sh
@@ -21,6 +21,7 @@ fi
 [ -n "$LMS_SERVER" ]   && ARGS+=(-s "$LMS_SERVER")
 [ -n "$PLAYER_NAME" ]  && ARGS+=(-n "$PLAYER_NAME")
 [ "$NO_DSD" = "yes" ]  && ARGS+=(--no-dsd)
+[ "$SET_VOLUME_100" = "yes" ] && ARGS+=(--set-volume-100)
 [ -n "$INTERFACE" ]    && ARGS+=(--interface "$INTERFACE")
 [ -n "$HTTP_PORT" ]    && ARGS+=(--http-port "$HTTP_PORT")
 [ "$VERBOSE" = "yes" ] && ARGS+=(-v)

--- a/install.sh
+++ b/install.sh
@@ -442,12 +442,14 @@ install_systemd() {
         # Save user values from existing config
         local saved_renderer="" saved_renderer_url="" saved_lms="" saved_player=""
         local saved_no_dsd="" saved_interface="" saved_http_port="" saved_verbose=""
+        local saved_set_volume_100=""
         . /etc/default/slim2upnp 2>/dev/null || true
         saved_renderer="$RENDERER"
         saved_renderer_url="$RENDERER_URL"
         saved_lms="$LMS_SERVER"
         saved_player="$PLAYER_NAME"
         saved_no_dsd="$NO_DSD"
+        saved_set_volume_100="$SET_VOLUME_100"
         saved_interface="$INTERFACE"
         saved_http_port="$HTTP_PORT"
         saved_verbose="$VERBOSE"
@@ -461,6 +463,7 @@ install_systemd() {
         [ -n "$saved_lms" ] && sed -i "s|^LMS_SERVER=.*|LMS_SERVER=\"$saved_lms\"|" /etc/default/slim2upnp
         [ -n "$saved_player" ] && sed -i "s|^PLAYER_NAME=.*|PLAYER_NAME=\"$saved_player\"|" /etc/default/slim2upnp
         [ -n "$saved_no_dsd" ] && sed -i "s|^NO_DSD=.*|NO_DSD=\"$saved_no_dsd\"|" /etc/default/slim2upnp
+        [ -n "$saved_set_volume_100" ] && sed -i "s|^SET_VOLUME_100=.*|SET_VOLUME_100=\"$saved_set_volume_100\"|" /etc/default/slim2upnp
         [ -n "$saved_interface" ] && sed -i "s|^INTERFACE=.*|INTERFACE=\"$saved_interface\"|" /etc/default/slim2upnp
         [ -n "$saved_http_port" ] && sed -i "s|^HTTP_PORT=.*|HTTP_PORT=\"$saved_http_port\"|" /etc/default/slim2upnp
         [ -n "$saved_verbose" ] && sed -i "s|^VERBOSE=.*|VERBOSE=\"$saved_verbose\"|" /etc/default/slim2upnp
@@ -511,12 +514,14 @@ install_openrc() {
     if [ -f /etc/conf.d/slim2upnp ]; then
         local saved_renderer="" saved_renderer_url="" saved_lms="" saved_player=""
         local saved_no_dsd="" saved_interface="" saved_http_port="" saved_verbose=""
+        local saved_set_volume_100=""
         . /etc/conf.d/slim2upnp 2>/dev/null || true
         saved_renderer="$RENDERER"
         saved_renderer_url="$RENDERER_URL"
         saved_lms="$LMS_SERVER"
         saved_player="$PLAYER_NAME"
         saved_no_dsd="$NO_DSD"
+        saved_set_volume_100="$SET_VOLUME_100"
         saved_interface="$INTERFACE"
         saved_http_port="$HTTP_PORT"
         saved_verbose="$VERBOSE"
@@ -528,6 +533,7 @@ install_openrc() {
         [ -n "$saved_lms" ] && sed -i "s|^LMS_SERVER=.*|LMS_SERVER=\"$saved_lms\"|" /etc/conf.d/slim2upnp
         [ -n "$saved_player" ] && sed -i "s|^PLAYER_NAME=.*|PLAYER_NAME=\"$saved_player\"|" /etc/conf.d/slim2upnp
         [ -n "$saved_no_dsd" ] && sed -i "s|^NO_DSD=.*|NO_DSD=\"$saved_no_dsd\"|" /etc/conf.d/slim2upnp
+        [ -n "$saved_set_volume_100" ] && sed -i "s|^SET_VOLUME_100=.*|SET_VOLUME_100=\"$saved_set_volume_100\"|" /etc/conf.d/slim2upnp
         [ -n "$saved_interface" ] && sed -i "s|^INTERFACE=.*|INTERFACE=\"$saved_interface\"|" /etc/conf.d/slim2upnp
         [ -n "$saved_http_port" ] && sed -i "s|^HTTP_PORT=.*|HTTP_PORT=\"$saved_http_port\"|" /etc/conf.d/slim2upnp
         [ -n "$saved_verbose" ] && sed -i "s|^VERBOSE=.*|VERBOSE=\"$saved_verbose\"|" /etc/conf.d/slim2upnp

--- a/src/AudioHttpServer.cpp
+++ b/src/AudioHttpServer.cpp
@@ -488,8 +488,10 @@ void AudioHttpServer::handleClient(int clientSocket) {
     if (reqLen <= 0) return;
     reqBuf[reqLen] = '\0';
 
-    // Basic HTTP request validation
-    if (strncmp(reqBuf, "GET ", 4) != 0) {
+    // Only GET and HEAD are supported. HEAD is used by some DLNA renderers
+    // (and the getContentFeatures.dlna.org probe) to fetch headers without a body.
+    bool isHead = (strncmp(reqBuf, "HEAD ", 5) == 0);
+    if (!isHead && strncmp(reqBuf, "GET ", 4) != 0) {
         const char* resp = "HTTP/1.1 405 Method Not Allowed\r\nContent-Length: 0\r\n\r\n";
         send(clientSocket, resp, strlen(resp), MSG_NOSIGNAL);
         return;
@@ -503,8 +505,17 @@ void AudioHttpServer::handleClient(int clientSocket) {
     }
     if (!m_readyToServe.load() || !m_running.load()) return;
 
-    // Build HTTP response headers
+    // Build HTTP response headers.
+    //
+    // DLNA compliance: strict renderers (notably GStreamer-based ones, e.g.
+    // Lyngdorf) send a `getContentFeatures.dlna.org` probe and expect a
+    // `contentFeatures.dlna.org` response header, otherwise they refuse the
+    // stream. We advertise a non-seekable HTTP audio stream:
+    //   DLNA.ORG_OP=00     no byte-range / time-seek operations (Accept-Ranges: none)
+    //   DLNA.ORG_FLAGS     streaming + background + http-stalling + DLNA 1.5
     std::string mimeType = getMimeType();
+    static const char* DLNA_CONTENT_FEATURES =
+        "DLNA.ORG_OP=00;DLNA.ORG_FLAGS=01700000000000000000000000000000";
     std::string responseHeader =
         "HTTP/1.1 200 OK\r\n"
         "Content-Type: " + mimeType + "\r\n"
@@ -512,13 +523,17 @@ void AudioHttpServer::handleClient(int clientSocket) {
         "Connection: close\r\n"
         "Cache-Control: no-cache\r\n"
         "transferMode.dlna.org: Streaming\r\n"
+        "contentFeatures.dlna.org: " + DLNA_CONTENT_FEATURES + "\r\n"
         "\r\n";
 
     // Send HTTP headers
     if (send(clientSocket, responseHeader.c_str(), responseHeader.size(), MSG_NOSIGNAL) < 0) {
-        LOG_ERROR("[AudioHttpServer] Failed to send HTTP header: " << strerror(errno));
+        LOG_DEBUG("[AudioHttpServer] Failed to send HTTP header: " << strerror(errno));
         return;
     }
+
+    // HEAD: headers only, no body (the renderer is just probing).
+    if (isHead) return;
 
     // Send audio container header (WAV or DSF) — skip in passthrough mode
     if (m_passthroughMime.empty()) {

--- a/src/AudioHttpServer.h
+++ b/src/AudioHttpServer.h
@@ -157,7 +157,10 @@ private:
     std::condition_variable m_dataAvailable;    // Consumer waits
     std::condition_variable m_spaceAvailable;   // Producer waits
 
-    static constexpr size_t MIN_BUFFER_SIZE = 64 * 1024;       // 64 KB
+    // Must stay larger than main.cpp's PREBUFFER_BYTES (256 KB): the prebuffer
+    // loop fills the ring before the HTTP server starts draining it, so a
+    // capacity below the prebuffer target would deadlock writeAudio().
+    static constexpr size_t MIN_BUFFER_SIZE = 512 * 1024;      // 512 KB
     static constexpr size_t MAX_BUFFER_SIZE = 32 * 1024 * 1024; // 32 MB
     static constexpr double PCM_BUFFER_SECONDS = 4.0;
     static constexpr double DSD_BUFFER_SECONDS = 2.0;

--- a/src/Config.h
+++ b/src/Config.h
@@ -31,6 +31,8 @@ struct Config {
     int maxSampleRate = 1536000;
     bool dsdEnabled = true;
     bool calibrateElapsed = true;       // poll GetTransportInfo at start to align elapsed clock with renderer PLAYING state
+    bool forceVolume100 = false;        // force renderer volume to 100% on connect (bit-perfect renderers like DirettaRendererUPnP).
+                                        // OFF by default — forcing 100% on a real amp/preamp (e.g. Lyngdorf) is dangerous.
 
     // Logging
     bool verbose = false;

--- a/src/Config.h
+++ b/src/Config.h
@@ -33,6 +33,8 @@ struct Config {
     bool calibrateElapsed = true;       // poll GetTransportInfo at start to align elapsed clock with renderer PLAYING state
     bool forceVolume100 = false;        // force renderer volume to 100% on connect (bit-perfect renderers like DirettaRendererUPnP).
                                         // OFF by default — forcing 100% on a real amp/preamp (e.g. Lyngdorf) is dangerous.
+    bool didlMetadata = true;           // send DIDL-Lite metadata (with <res protocolInfo>) in Set(Next)AVTransportURI.
+                                        // Needed by strict DLNA renderers (GStreamer-based, DSD). --no-didl-metadata to disable.
 
     // Logging
     bool verbose = false;

--- a/src/UPnPController.cpp
+++ b/src/UPnPController.cpp
@@ -533,6 +533,50 @@ bool UPnPController::setNextAVTransportURI(const std::string& uri,
     return false;
 }
 
+namespace {
+// Escape the five XML predefined entities so the value is safe inside the
+// DIDL-Lite document (which libupnp will itself escape again into the SOAP).
+std::string xmlEscape(const std::string& in) {
+    std::string out;
+    out.reserve(in.size());
+    for (char c : in) {
+        switch (c) {
+            case '&':  out += "&amp;";  break;
+            case '<':  out += "&lt;";   break;
+            case '>':  out += "&gt;";   break;
+            case '"':  out += "&quot;"; break;
+            case '\'': out += "&apos;"; break;
+            default:   out += c;        break;
+        }
+    }
+    return out;
+}
+}  // namespace
+
+std::string UPnPController::buildAudioDidl(const std::string& uri,
+                                           const std::string& mimeType) {
+    // Non-seekable HTTP audio stream: OP=00 (no range/time-seek, matches the
+    // server's "Accept-Ranges: none"), FLAGS = streaming + background +
+    // http-stalling + DLNA 1.5. No DLNA.ORG_PN (formats like FLAC/DSF have no
+    // standard profile name) — strict renderers still accept a bare descriptor.
+    std::string protocolInfo = "http-get:*:" + mimeType +
+        ":DLNA.ORG_OP=00;DLNA.ORG_FLAGS=01700000000000000000000000000000";
+
+    return
+        "<DIDL-Lite "
+        "xmlns=\"urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/\" "
+        "xmlns:dc=\"http://purl.org/dc/elements/1.1/\" "
+        "xmlns:upnp=\"urn:schemas-upnp-org:metadata-1-0/upnp/\">"
+        "<item id=\"0\" parentID=\"-1\" restricted=\"1\">"
+        "<dc:title>slim2UPnP</dc:title>"
+        "<upnp:class>object.item.audioItem.musicTrack</upnp:class>"
+        "<res protocolInfo=\"" + xmlEscape(protocolInfo) + "\">"
+        + xmlEscape(uri) +
+        "</res>"
+        "</item>"
+        "</DIDL-Lite>";
+}
+
 bool UPnPController::play(const std::string& speed) {
     std::lock_guard<std::mutex> lock(m_mutex);
 

--- a/src/UPnPController.cpp
+++ b/src/UPnPController.cpp
@@ -192,8 +192,12 @@ bool UPnPController::discoverRenderer(const std::string& rendererMatch,
     // Query protocol info after discovery
     queryProtocolInfo();
 
-    // Force volume to 100% for bit-perfect playback
-    setVolume(100);
+    // Force volume to 100% only when explicitly requested (bit-perfect
+    // renderers like DirettaRendererUPnP). Off by default — forcing 100%
+    // on a real amp/preamp is dangerous.
+    if (m_forceVolume100) {
+        setVolume(100);
+    }
 
     LOG_INFO("[UPnP] Renderer found: " << m_renderer.friendlyName
              << " (" << m_renderer.uuid << ")");
@@ -250,7 +254,9 @@ bool UPnPController::connectDirect(const std::string& descriptionURL) {
     }
 
     queryProtocolInfo();
-    setVolume(100);
+    if (m_forceVolume100) {
+        setVolume(100);
+    }
 
     LOG_INFO("[UPnP] Connected to: " << m_renderer.friendlyName
              << " (" << m_renderer.uuid << ")");

--- a/src/UPnPController.h
+++ b/src/UPnPController.h
@@ -72,6 +72,14 @@ public:
                            const std::string& metadata = "");
     bool setNextAVTransportURI(const std::string& uri,
                                const std::string& metadata = "");
+
+    /// Build minimal DIDL-Lite metadata (a single audio item with a
+    /// <res protocolInfo="http-get:*:MIME:DLNA.ORG_*"> entry) for a stream URL.
+    /// Strict DLNA renderers (GStreamer-based, or DSD-capable) need this in
+    /// CurrentURIMetaData/NextURIMetaData to accept the URI. The returned XML
+    /// is passed verbatim as the metadata arg; libupnp escapes it into the SOAP.
+    static std::string buildAudioDidl(const std::string& uri,
+                                      const std::string& mimeType);
     bool play(const std::string& speed = "1");
     bool stop();
     bool pause();

--- a/src/UPnPController.h
+++ b/src/UPnPController.h
@@ -78,6 +78,12 @@ public:
 
     // --- RenderingControl ---
 
+    /// If enabled, the renderer volume is forced to 100% on connect (for
+    /// bit-perfect renderers that ignore volume, e.g. DirettaRendererUPnP).
+    /// Disabled by default: forcing 100% on a real amp/preamp is dangerous.
+    /// Call before discoverRenderer()/connectDirect().
+    void setForceVolume100(bool enable) { m_forceVolume100 = enable; }
+
     bool setVolume(int volume);
     int getVolume();
 
@@ -159,6 +165,7 @@ private:
     RendererInfo m_renderer;
     std::atomic<bool> m_ready{false};
     bool m_initialized = false;
+    bool m_forceVolume100 = false;      // see setForceVolume100()
     mutable std::mutex m_mutex;
 
     // --- Watchdog ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,7 +35,7 @@
 #include <unistd.h>
 #include <poll.h>
 
-#define SLIM2UPNP_VERSION "0.1.25-beta"
+#define SLIM2UPNP_VERSION "0.1.26-beta"
 
 // ============================================
 // Globals
@@ -187,6 +187,9 @@ Config parseArguments(int argc, char* argv[]) {
         else if (arg == "--set-volume-100") {
             config.forceVolume100 = true;
         }
+        else if (arg == "--no-didl-metadata") {
+            config.didlMetadata = false;
+        }
         else if (arg == "--list-renderers" || arg == "-l") {
             config.listRenderers = true;
         }
@@ -224,6 +227,8 @@ Config parseArguments(int argc, char* argv[]) {
                       << "  --set-volume-100       Force renderer volume to 100% on connect\n"
                       << "                         (for bit-perfect renderers like DirettaRendererUPnP;\n"
                       << "                          OFF by default — unsafe on a real amp/preamp)\n"
+                      << "  --no-didl-metadata     Don't send DIDL-Lite metadata in SetAVTransportURI\n"
+                      << "                         (metadata is sent by default; needed by strict DLNA renderers)\n"
                       << "\n"
                       << "Logging:\n"
                       << "  -v, --verbose          Debug output (log level: DEBUG)\n"
@@ -480,6 +485,7 @@ int main(int argc, char* argv[]) {
     std::cout << "  Max Rate:   " << config.maxSampleRate << " Hz" << std::endl;
     std::cout << "  DSD:        " << (config.dsdEnabled ? "enabled" : "disabled") << std::endl;
     std::cout << "  Volume:     " << (config.forceVolume100 ? "forced to 100%" : "untouched") << std::endl;
+    std::cout << "  DIDL meta:  " << (config.didlMetadata ? "enabled" : "disabled") << std::endl;
     if (!config.macAddress.empty()) {
         std::cout << "  MAC:        " << config.macAddress << std::endl;
     }
@@ -673,9 +679,16 @@ int main(int argc, char* argv[]) {
                         audioFmt.bitDepth = bd ? bd : 16;
                         audioFmt.channels = ch;
                     } else {
-                        audioFmt.sampleRate = 44100;  // Default for compressed formats
+                        // Placeholder values — in passthrough the renderer decodes,
+                        // so these only size the ring buffer. Flag DSD so the buffer
+                        // uses the DSD multiplier and the log isn't misleading.
+                        audioFmt.sampleRate = 44100;
                         audioFmt.bitDepth = 24;
                         audioFmt.channels = 2;
+                        audioFmt.isDSD =
+                            contentType.find("dsf") != std::string::npos ||
+                            contentType.find("dff") != std::string::npos ||
+                            contentType.find("dsd") != std::string::npos;
                     }
                     audioServerPtr->setFormat(audioFmt);
                     audioServerPtr->setPassthroughMime(contentType);
@@ -828,10 +841,16 @@ int main(int argc, char* argv[]) {
                             currentSlot.store(1 - oldSlot);
                         }
                         bool doCalibrate = config.calibrateElapsed;
+                        bool sendDidl = config.didlMetadata;
                         std::thread([upnpPtr, audioServerPtr, &slimproto,
                                      &streamGeneration, thisGeneration,
-                                     &playStartNs, doCalibrate]() {
-                            upnpPtr->setAVTransportURI(audioServerPtr->getStreamURL());
+                                     &playStartNs, doCalibrate, sendDidl]() {
+                            std::string url = audioServerPtr->getStreamURL();
+                            std::string meta = sendDidl
+                                ? UPnPController::buildAudioDidl(
+                                      url, audioServerPtr->getMimeType())
+                                : "";
+                            upnpPtr->setAVTransportURI(url, meta);
                             if (streamGeneration.load() != thisGeneration) return;
                             upnpPtr->play();
                             slimproto->sendStat(StatEvent::STMl);
@@ -871,8 +890,12 @@ int main(int argc, char* argv[]) {
                         int oldSlot = currentSlot.load();
                         int newSlot = 1 - oldSlot;
                         std::string nextURL = servers[newSlot]->getStreamURL();
+                        std::string nextMeta = config.didlMetadata
+                            ? UPnPController::buildAudioDidl(
+                                  nextURL, servers[newSlot]->getMimeType())
+                            : "";
                         LOG_INFO("[Gapless] SetNextAVTransportURI: " << nextURL);
-                        upnpPtr->setNextAVTransportURI(nextURL);
+                        upnpPtr->setNextAVTransportURI(nextURL, nextMeta);
                         servers[oldSlot]->signalEndOfStream();
                         currentSlot.store(newSlot);
                         slimproto->sendStat(StatEvent::STMl);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,7 +35,7 @@
 #include <unistd.h>
 #include <poll.h>
 
-#define SLIM2UPNP_VERSION "0.1.26-beta"
+#define SLIM2UPNP_VERSION "0.1.27-beta"
 
 // ============================================
 // Globals
@@ -680,15 +680,15 @@ int main(int argc, char* argv[]) {
                         audioFmt.channels = ch;
                     } else {
                         // Placeholder values — in passthrough the renderer decodes,
-                        // so these only size the ring buffer. Flag DSD so the buffer
-                        // uses the DSD multiplier and the log isn't misleading.
+                        // so these only size the ring buffer (PCM math: ~1 MB).
+                        // Do NOT set isDSD here: bytesPerSecond() returns
+                        // (dsdRate/8)*channels and dsdRate is 0 in passthrough, so
+                        // the buffer would collapse to MIN_BUFFER_SIZE (64 KB) — far
+                        // below the 256 KB prebuffer target — and writeAudio() would
+                        // deadlock (no SetAVTransportURI/Play → no sound on DSD).
                         audioFmt.sampleRate = 44100;
                         audioFmt.bitDepth = 24;
                         audioFmt.channels = 2;
-                        audioFmt.isDSD =
-                            contentType.find("dsf") != std::string::npos ||
-                            contentType.find("dff") != std::string::npos ||
-                            contentType.find("dsd") != std::string::npos;
                     }
                     audioServerPtr->setFormat(audioFmt);
                     audioServerPtr->setPassthroughMime(contentType);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,7 +35,7 @@
 #include <unistd.h>
 #include <poll.h>
 
-#define SLIM2UPNP_VERSION "0.1.24-beta"
+#define SLIM2UPNP_VERSION "0.1.25-beta"
 
 // ============================================
 // Globals
@@ -184,6 +184,9 @@ Config parseArguments(int argc, char* argv[]) {
         else if (arg == "--no-play-calibration") {
             config.calibrateElapsed = false;
         }
+        else if (arg == "--set-volume-100") {
+            config.forceVolume100 = true;
+        }
         else if (arg == "--list-renderers" || arg == "-l") {
             config.listRenderers = true;
         }
@@ -218,6 +221,9 @@ Config parseArguments(int argc, char* argv[]) {
                       << "  --max-rate <hz>        Max sample rate (default: 1536000)\n"
                       << "  --no-dsd               Disable DSD support\n"
                       << "  --no-play-calibration  Disable renderer PLAYING-state elapsed calibration\n"
+                      << "  --set-volume-100       Force renderer volume to 100% on connect\n"
+                      << "                         (for bit-perfect renderers like DirettaRendererUPnP;\n"
+                      << "                          OFF by default — unsafe on a real amp/preamp)\n"
                       << "\n"
                       << "Logging:\n"
                       << "  -v, --verbose          Debug output (log level: DEBUG)\n"
@@ -369,6 +375,7 @@ int main(int argc, char* argv[]) {
         std::cerr << "Failed to initialize UPnP" << std::endl;
         return 1;
     }
+    upnp->setForceVolume100(config.forceVolume100);
 
     // Connect to renderer: direct URL or SSDP discovery
     if (!config.rendererURL.empty()) {
@@ -472,6 +479,7 @@ int main(int argc, char* argv[]) {
     std::cout << "  HTTP B:     " << audioServerB->getStreamURL() << std::endl;
     std::cout << "  Max Rate:   " << config.maxSampleRate << " Hz" << std::endl;
     std::cout << "  DSD:        " << (config.dsdEnabled ? "enabled" : "disabled") << std::endl;
+    std::cout << "  Volume:     " << (config.forceVolume100 ? "forced to 100%" : "untouched") << std::endl;
     if (!config.macAddress.empty()) {
         std::cout << "  MAC:        " << config.macAddress << std::endl;
     }

--- a/webui/profiles/slim2upnp.json
+++ b/webui/profiles/slim2upnp.json
@@ -61,6 +61,17 @@
                         {"value": "", "label": "No (DSD enabled)"},
                         {"value": "yes", "label": "Yes (force PCM only)"}
                     ]
+                },
+                {
+                    "key": "SET_VOLUME_100",
+                    "type": "select",
+                    "label": "Force volume to 100%",
+                    "description": "Force the renderer volume to 100% on connect. ONLY for bit-perfect renderers that ignore volume (e.g. DirettaRendererUPnP). WARNING: do NOT enable with a real amplifier/preamp (e.g. Lyngdorf) — it sets the output to full scale.",
+                    "default": "",
+                    "options": [
+                        {"value": "", "label": "No (leave volume untouched)"},
+                        {"value": "yes", "label": "Yes (force 100% — bit-perfect renderers only)"}
+                    ]
                 }
             ]
         },


### PR DESCRIPTION
Bundles the volume-safety fix (**supersedes #7**) and the DLNA-compatibility work for strict renderers reported by @smoothquark in #4, #5 and #6. Version **0.1.27-beta**.

## What's in here

### 1. Volume no longer forced to 100% by default (#6 point 3)
`SetVolume(100)` was called on every connect. Dangerous on a real amp/preamp (Lyngdorf). Now left untouched by default; opt-in via `--set-volume-100` / `SET_VOLUME_100` / webUI toggle (for renderers that ignore volume, e.g. DirettaRendererUPnP).

### 2. DIDL-Lite metadata on Set(Next)AVTransportURI (#4 #5 #6)
The transport URI was set with empty metadata. Strict DLNA renderers (GStreamer-based, DSD-capable) need a `<res protocolInfo="http-get:*:MIME:DLNA.ORG_*">` descriptor to accept the URI. `UPnPController::buildAudioDidl()` now generates a minimal DIDL-Lite item. Toggle with `--no-didl-metadata` for A/B testing.

### 3. DLNA HTTP response headers + HEAD support (#6)
The audio server now advertises `contentFeatures.dlna.org` (matching the DIDL `protocolInfo`) and answers `HEAD` requests with headers only — needed by GStreamer-based renderers (Lyngdorf) that probe before streaming.

### 4. Fix DSD passthrough deadlock (regression caught in review)
An interim 0.1.26 change flagged the placeholder format as DSD; `bytesPerSecond()` then returned 0 (dsdRate unset in passthrough), collapsing the ring buffer to 64 KB below the 256 KB prebuffer → `writeAudio()` deadlock → no DSD sound. Reverted, and `MIN_BUFFER_SIZE` raised to 512 KB to make this class of deadlock impossible.

## Testing

Regression-tested on **DirettaRendererUPnP** (the maintainer's hardware):
- ✅ FLAC plays (with DIDL metadata + DLNA headers)
- ✅ DSD/DSF plays (after the deadlock fix)
- ✅ Volume left untouched

**Not yet field-tested on the Lyngdorf TDAI-3400 / Zidoo Z3000 Pro** (maintainer doesn't own them) — items 2 and 3 target those devices and will be validated via @smoothquark. `--no-didl-metadata` is provided as a fallback. See CHANGELOG for full details.

Closes nothing automatically — #4/#5/#6 stay open until smoothquark confirms on the actual hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)